### PR TITLE
ci(circle): Add rspec_junit_formatter gem

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,11 @@
 dependencies:
   pre:
     - gem install bundler --pre
+
+test:
+  override:
+    - RAILS_ENV=test bundle exec rspec -r rspec_junit_formatter --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
+
+general:
+  artifacts:
+    - 'coverage'

--- a/ticketfy-cli.gemspec
+++ b/ticketfy-cli.gemspec
@@ -19,9 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler',    '~> 1.12'
-  spec.add_development_dependency 'rake',       '~> 10.0'
-  spec.add_development_dependency 'rspec',      '~> 3.0'
-  spec.add_development_dependency 'byebug',     '~> 9.0', '>= 9.0.6'
-  spec.add_development_dependency 'simplecov',  '~> 0.12.0'
+  spec.add_development_dependency 'bundler',                '~> 1.12'
+  spec.add_development_dependency 'rake',                   '~> 10.0'
+  spec.add_development_dependency 'rspec',                  '~> 3.0'
+  spec.add_development_dependency 'byebug',                 '~> 9.0', '>= 9.0.6'
+  spec.add_development_dependency 'simplecov',              '~> 0.12.0'  
+  spec.add_development_dependency 'rspec_junit_formatter',  '0.2.2'
 end


### PR DESCRIPTION
In order to allow Circle CI to collect test metadata

More: https://circleci.com/docs/test-metadata/#rspec

refers #5